### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -23,7 +23,7 @@ def test_decode_large_int(benchmark):
     assert bdecode(b'i25735241490e') == 25735241490
 
     MAX_SIZE = sys.maxsize + 1
-    BENCODED_MAXSIZE = ('i%de' % MAX_SIZE).encode()
+    BENCODED_MAXSIZE = ('i{0:d}e'.format(MAX_SIZE)).encode()
     assert benchmark(bdecode, BENCODED_MAXSIZE) == MAX_SIZE
 
 

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -22,7 +22,7 @@ def test_encode_large_int(benchmark):
     assert bencode(1455189890) == b'i1455189890e'
     assert bencode(25735241490) == b'i25735241490e'
     MAX_SIZE = sys.maxsize + 1
-    BENCODED_MAXSIZE = ('i%de' % MAX_SIZE).encode()
+    BENCODED_MAXSIZE = ('i{0:d}e'.format(MAX_SIZE)).encode()
 
     assert benchmark(bencode, MAX_SIZE) == BENCODED_MAXSIZE
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:whtsky:bencoder.pyx?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:whtsky:bencoder.pyx?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)