### PR TITLE
bump with bdecode2, which does not error on extra bytes

### DIFF
--- a/bencoder.pyx
+++ b/bencoder.pyx
@@ -88,15 +88,18 @@ for func, keys in [
             decode_func[ord(key)] = func
 
 
-def bdecode(bytes x):
+def bdecode2(bytes x):
     try:
         r, l = decode_func[x[0]](x, 0)
     except (IndexError, KeyError, ValueError):
         raise BTFailure("not a valid bencoded string")
+    return r, l
+
+def bdecode(bytes x):
+    r, l = bdecode2(x)
     if l != len(x):
         raise BTFailure("invalid bencoded value (data after valid prefix)")
     return r
-
 
 def encode(v, r):
     tp = type(v)


### PR DESCRIPTION
This follows up on #5, which was related to work on https://github.com/boramalper/magnetico/issues/5.

This PR adds the required functionality to bencoder.pyx, and attempts to do so while changing the fewest lines possible. 