### PR TITLE
Fix bytes parsing when used with python-future

### DIFF
--- a/bencoder.pyx
+++ b/bencoder.pyx
@@ -125,7 +125,7 @@ cdef encode_long(x, list r):
     r.append(b'e')
 
 
-cdef encode_bytes(bytes x, list r):
+cdef encode_bytes(x, list r):
     r.append(str(len(x)).encode())
     r.append(b':')
     r.append(x)


### PR DESCRIPTION
This allows bencoder.pyx to be used with [python-future](http://python-future.org/), if the bytes type is enforced I get this error:
```
  File "bencoder.pyx", line 174, in bencoder.bencode
  File "bencoder.pyx", line 106, in bencoder.encode
  File "stringsource", line 67, in cfunc.to_py.__Pyx_CFunc_object____object____list___to_py.wrap
  File "bencoder.pyx", line 155, in bencoder.encode_dict
  File "bencoder.pyx", line 106, in bencoder.encode
  File "stringsource", line 67, in cfunc.to_py.__Pyx_CFunc_object____object____list___to_py.wrap
  File "bencoder.pyx", line 154, in bencoder.encode_dict
TypeError: Expected bytes, got newbytes
```